### PR TITLE
httpx-sse 0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,19 +10,19 @@ source:
   sha256: 1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721
 
 build:
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - setuptools
     - setuptools-scm
     - wheel
     - pip
   run:
-    - python >=3.8
+    - python
     - httpx
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721
 
 build:
-  skip: True  # [py<38]
+  # nothing provides h2 3.* needed by httpcore on s390x
+  skip: True  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,15 @@ test:
 
 about:
   summary: Consume Server-Sent Event (SSE) messages with HTTPX.
+  description: |
+    httpx-sse provides the connect_sse and aconnect_sse helpers for connecting to an SSE endpoint.
+    The resulting EventSource object exposes the .iter_sse() and .aiter_sse() methods to iterate over the server-sent events.
   home: https://github.com/florimondmanca/httpx-sse
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://github.com/florimondmanca/httpx-sse
+  dev_url: https://github.com/florimondmanca/httpx-sse
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6659](https://anaconda.atlassian.net/browse/PKG-6659)
- [Upstream repository](https://github.com/florimondmanca/httpx-sse/tree/0.4.0)
- [Upstream changelog/diff](https://github.com/florimondmanca/httpx-sse/blob/0.4.0/CHANGELOG.md)
- Relevant dependency PRs:
  - `httpx-sse` ➡️ `langchain-community`

### Explanation of changes:

- Fork from conda forge
- Recipe standardization
- Linter fixes
- Skip s390x


[PKG-6659]: https://anaconda.atlassian.net/browse/PKG-6659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ